### PR TITLE
Prepare for npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+/*
+!/src/
+!/bin/
+!/wasm-polyfill.min.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "wasm-polyfill",
   "version": "0.1.0",
+  "main": "src/index.js",
+  "bin": {
+    "translate": "./bin/translate.js"
+  },
   "devDependencies": {
     "mocha": "^3.2.0",
     "rollup": "^0.39.2",


### PR DESCRIPTION
Related to #2.
Basically it keeps only sources, CLI utility and minified polyfill in npm package.